### PR TITLE
Arreglado

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ venv.bak/
 .mypy_cache/
 
 *~
+
+.precomp

--- a/t/00-sanity.t
+++ b/t/00-sanity.t
@@ -4,11 +4,10 @@ use IncidenciasTrafico::NoTipo;
 use Test;
 
 my $tipo = Atasco;
-my $test = IncidenciasTrafico::Incidencia.new(2,"hola",:$tipo);
+my $test = IncidenciasTrafico::Incidencia.new(:2ubicacion,:description("hola"),:$tipo);
 
-say "ubicacion: ";
-say $test.ubicacion;
-say "descripcion: ";
-say $test.descripcion;
+ok $test.ubicacion, "Ubicación";
+
+ok $test.descripcion "Descripcion";
 
 done-testing;


### PR DESCRIPTION
Pues eso. Hay que usar en este caso argumentos con nombre, porque es como están declarados en BUILD. Además, $tipo lo podemos pasar de esa forma porque equivale a tipo => $tipo
He metido los tests, de camino.